### PR TITLE
[PAGOPA-1942] fix: removed redundant sessionId field

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: wisp-soap-converter-chart
 description: Wisp Soap Conveter
 type: application
-version: 2.42.0
-appVersion: 0.2.7-87-PAGOPA-1894-fix-sessionId
+version: 2.43.0
+appVersion: 0.2.7-88-PAGOPA-1942
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-wisp-soap-converter
-    tag: 0.2.7-87-PAGOPA-1894-fix-sessionId
+    tag: 0.2.7-88-PAGOPA-1942
   canaryDelivery:
     create: false
 wispsoapconverter:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -85,7 +85,7 @@ wispsoapconverter:
     AZURE_COSMOS_DB_NAME: "wispconverter"
     AZURE_COSMOS_TABLE_NAME_DATA: "data"
     AZURE_COSMOS_TABLE_NAME_EVENTS: "re"
-    ADAPTER_ECOMMERCE_URL: "https://dev.wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?sessionId=REPLACE&idSession=REPLACE"
+    ADAPTER_ECOMMERCE_URL: "https://dev.wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?idSession=REPLACE"
     RE_XML_LOG_ACTIVE: "false"
     RE_JSON_LOG_ACTIVE: "true"
   secretProvider:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -85,7 +85,7 @@ wispsoapconverter:
     AZURE_COSMOS_DB_NAME: "wispconverter"
     AZURE_COSMOS_TABLE_NAME_DATA: "data"
     AZURE_COSMOS_TABLE_NAME_EVENTS: "re"
-    ADAPTER_ECOMMERCE_URL: "https://wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?sessionId="
+    ADAPTER_ECOMMERCE_URL: "https://wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?idSession=REPLACE"
     RE_XML_LOG_ACTIVE: "false"
     RE_JSON_LOG_ACTIVE: "true"
   secretProvider:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-wisp-soap-converter
-    tag: 0.2.7-87-PAGOPA-1894-fix-sessionId
+    tag: 0.2.7-88-PAGOPA-1942
   canaryDelivery:
     create: false
 wispsoapconverter:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-wisp-soap-converter
-    tag: 0.2.7-87-PAGOPA-1894-fix-sessionId
+    tag: 0.2.7-88-PAGOPA-1942
   canaryDelivery:
     create: false
 wispsoapconverter:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -85,7 +85,7 @@ wispsoapconverter:
     AZURE_COSMOS_DB_NAME: "wispconverter"
     AZURE_COSMOS_TABLE_NAME_DATA: "data"
     AZURE_COSMOS_TABLE_NAME_EVENTS: "re"
-    ADAPTER_ECOMMERCE_URL: "https://uat.wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?sessionId=REPLACE&idSession=REPLACE"
+    ADAPTER_ECOMMERCE_URL: "https://uat.wisp2.pagopa.it/wisp-converter/redirect/api/v1/payments?idSession=REPLACE"
     RE_XML_LOG_ACTIVE: "false"
     RE_JSON_LOG_ACTIVE: "true"
   secretProvider:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Wisp soap converter",
     "description": "Wisp soap converter",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.7-87-PAGOPA-1894-fix-sessionId"
+    "version": "0.2.7-88-PAGOPA-1942"
   },
   "servers": [
     {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.7-87-PAGOPA-1894-fix-sessionId"
+ThisBuild / version := "0.2.7-88-PAGOPA-1942"


### PR DESCRIPTION
This PR contains the deletion of the `sessionId` query parameter, no more useful and redundant because there is another field, named `idSession`, that has the same value.

#### List of Changes
 - Removed `sessionId` query parameter

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
