### PR TITLE
fix: resolved typo on `status` enumeration

### DIFF
--- a/wispsoapconverter/src/main/scala/it/gov/pagopa/actors/NodoInviaCarrelloRPTActor.scala
+++ b/wispsoapconverter/src/main/scala/it/gov/pagopa/actors/NodoInviaCarrelloRPTActor.scala
@@ -99,7 +99,7 @@ case class NodoInviaCarrelloRPTActorPerRequest(cosmosRepository: CosmosRepositor
           sessionId = None,
           sessionIdOriginal = Some(req.sessionId),
           payload = None,
-          esito = Esito.EXCECUTED_INTERNAL_STEP,
+          esito = Esito.EXECUTED_INTERNAL_STEP,
           tipoEvento = Some(actorClassId),
           sottoTipoEvento = SottoTipoEvento.INTERN,
           insertedTimestamp = soapRequest.timestamp,
@@ -226,7 +226,7 @@ case class NodoInviaCarrelloRPTActorPerRequest(cosmosRepository: CosmosRepositor
                 ccp = Some(rpt.datiVersamento.codiceContestoPagamento),
                 idDominio = Some(rpt.dominio.identificativoDominio),
                 status = Some(StatoRPTEnum.RPT_PARCHEGGIATA_NODO.toString),
-                esito = Esito.EXCECUTED_INTERNAL_STEP,
+                esito = Esito.EXECUTED_INTERNAL_STEP,
                 insertedTimestamp = now
               )
               reEventFunc(reRequest.copy(re = reCambioStatorpt), log, ddataMap)

--- a/wispsoapconverter/src/main/scala/it/gov/pagopa/actors/NodoInviaRPTActor.scala
+++ b/wispsoapconverter/src/main/scala/it/gov/pagopa/actors/NodoInviaRPTActor.scala
@@ -99,7 +99,7 @@ case class NodoInviaRPTActorPerRequest(cosmosRepository: CosmosRepository, actor
           sessionId = None,
           sessionIdOriginal = Some(req.sessionId),
           payload = None,
-          esito = Esito.EXCECUTED_INTERNAL_STEP,
+          esito = Esito.EXECUTED_INTERNAL_STEP,
           tipoEvento = Some(actorClassId),
           sottoTipoEvento = SottoTipoEvento.INTERN,
           insertedTimestamp = soapRequest.timestamp,
@@ -229,7 +229,7 @@ case class NodoInviaRPTActorPerRequest(cosmosRepository: CosmosRepository, actor
 
   def reCambioStato(stato: String, time: Instant, tipo: Option[String] = None): Unit = {
     reEventFunc(
-      ReRequest(req.sessionId, req.testCaseId, re.get.copy(status = Some(s"${tipo.getOrElse("")}${stato}"), insertedTimestamp = time, esito = Esito.EXCECUTED_INTERNAL_STEP), None),
+      ReRequest(req.sessionId, req.testCaseId, re.get.copy(status = Some(s"${tipo.getOrElse("")}${stato}"), insertedTimestamp = time, esito = Esito.EXECUTED_INTERNAL_STEP), None),
       log,
       ddataMap
     )

--- a/wispsoapconverter/src/main/scala/it/gov/pagopa/common/util/azure/cosmos/ReEventEntity.scala
+++ b/wispsoapconverter/src/main/scala/it/gov/pagopa/common/util/azure/cosmos/ReEventEntity.scala
@@ -28,7 +28,7 @@ object Esito extends Enumeration {
   val RECEIVED = Value
   val RECEIVED_FAILURE = Value
   val NEVER_RECEIVED = Value
-  val EXCECUTED_INTERNAL_STEP = Value
+  val EXECUTED_INTERNAL_STEP = Value
 }
 
 case class ReEventEntity(

--- a/wispsoapconverter/src/test/scala/it/gov/pagopa/tests/FormatUnitTests.scala
+++ b/wispsoapconverter/src/test/scala/it/gov/pagopa/tests/FormatUnitTests.scala
@@ -110,13 +110,13 @@ class FormatUnitTests extends AnyFlatSpec with should.Matchers {
       Re(
         Instant.now(), Componente.WISP_SOAP_CONVERTER, CategoriaEvento.INTERNAL,
         SottoTipoEvento.INTERN,
-        esito = Esito.EXCECUTED_INTERNAL_STEP,
+        esito = Esito.EXECUTED_INTERNAL_STEP,
         payload = Some(
           <xml>test</xml>.toString().getBytes
         )
       ),
       Some(ReExtra())
-    ).get == """Re Request => TIPO_EVENTO[INTERN/n.a] ESITO[EXCECUTED_INTERNAL_STEP] STATO[STATO non presente]""")
+    ).get == """Re Request => TIPO_EVENTO[INTERN/n.a] ESITO[EXECUTED_INTERNAL_STEP] STATO[STATO non presente]""")
 
   }
 
@@ -188,7 +188,7 @@ class FormatUnitTests extends AnyFlatSpec with should.Matchers {
       Re(
         Instant.now(), Componente.WISP_SOAP_CONVERTER, CategoriaEvento.INTERNAL,
         SottoTipoEvento.INTERN,
-        esito = Esito.EXCECUTED_INTERNAL_STEP,
+        esito = Esito.EXECUTED_INTERNAL_STEP,
         payload = Some(
           <xml>test
           </xml>.toString().getBytes


### PR DESCRIPTION
This PR contains a little fix made on `Esito` enumeration. This enumeration contains the values that the `outcome` field from RE event must have but a typo was made on `EXECUTED_INTERNAL_STEP`. The fix made provide the correction of this value.

#### List of Changes
 - resolved typo, changing value from `EXCECUTED_INTERNAL_STEP` to `EXECUTED_INTERNAL_STEP`

#### Motivation and Context
This change is required because the Technical Support's API cannot correctly read outcome value

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
